### PR TITLE
feat(auth): add Pi SDK login and review-only mode

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -347,15 +347,15 @@
     <script src="{% static 'js/cookiesConsent.portfolio.js' %}" defer></script>
     <script src="{% static 'js/pageLoader.js' %}" defer></script>
     <script src="{% static 'js/alerts.anim.js' %}" defer></script>
+    <script src="https://sdk.minepi.com/pi-sdk.js"></script>
+
+    {% block extra_scripts %}{% endblock %}
+
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('/sw.js').catch(()=>{});
       }
     </script>
-
-
-
-    {% block extra_scripts %}{% endblock %}
 
       <!-- Page Loader Overlay -->
     <div id="page-loader" class="page-loader" aria-hidden="true">

--- a/portfolio/settings.py
+++ b/portfolio/settings.py
@@ -42,6 +42,7 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # Conversión Pi-EUR 
 PI_EUR_PER_PI = Decimal(str(env("PI_EUR_PER_PI", default="0.30")))
 
+PI_ONLY_LOGIN = env("PI_ONLY_LOGIN", default=False) 
 
 # --- Apps ---
 INSTALLED_APPS = [

--- a/static/js/pi-auth.js
+++ b/static/js/pi-auth.js
@@ -1,0 +1,47 @@
+// --- Utilidades ---
+function getCsrf(name = "csrftoken") {
+  return document.cookie.split("; ")
+    .find(r => r.startsWith(name + "="))?.split("=")[1];
+}
+
+// Inicializa el SDK de Pi (llámalo lo antes posible)
+export function initPiSdk({ sandbox = true } = {}) {
+  if (!window.Pi) {
+    console.error("Pi SDK no cargado (window.Pi undefined)");
+    return;
+  }
+  // v2 es la versión actual del SDK moderno
+  window.Pi.init({ version: "2.0", sandbox });
+  // Debug info
+  console.log("Pi SDK init:", { sandbox });
+}
+
+// Login con Pi y POST al backend de Django
+export async function loginWithPi({ postUrl, onSuccessRedirect }) {
+  try {
+    if (!window.Pi) throw new Error("Pi SDK no inicializado");
+
+    const { accessToken } = await window.Pi.authenticate(["username", "payments"]);
+
+    const resp = await fetch(postUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrf() },
+      body: JSON.stringify({ accessToken }),
+    });
+
+    if (!resp.ok) {
+      const t = await resp.text().catch(() => "");
+      throw new Error(`pi_login falló: ${resp.status} ${t}`);
+    }
+
+    // Redirección (prioriza ?next=)
+    const urlNext = new URLSearchParams(window.location.search).get("next");
+    window.location = urlNext || onSuccessRedirect || "/";
+  } catch (e) {
+    console.error(e);
+    alert(
+      "No se pudo iniciar sesión con Pi.\n" +
+      "Verifica:\n• Estás en Pi Browser\n• Pi.init() ejecutado\n• Sandbox autorizado hoy"
+    );
+  }
+}

--- a/staticfiles/js/pi-auth.js
+++ b/staticfiles/js/pi-auth.js
@@ -1,0 +1,49 @@
+// static/js/pi-auth.js
+
+// --- Utilidades ---
+function getCsrf(name = "csrftoken") {
+  return document.cookie.split("; ")
+    .find(r => r.startsWith(name + "="))?.split("=")[1];
+}
+
+// Inicializa el SDK de Pi (llámalo lo antes posible)
+export function initPiSdk({ sandbox = true } = {}) {
+  if (!window.Pi) {
+    console.error("Pi SDK no cargado (window.Pi undefined)");
+    return;
+  }
+  // v2 es la versión actual del SDK moderno
+  window.Pi.init({ version: "2.0", sandbox });
+  // Debug opcional
+  // console.log("Pi SDK init:", { sandbox });
+}
+
+// Login con Pi y POST al backend de Django
+export async function loginWithPi({ postUrl, onSuccessRedirect }) {
+  try {
+    if (!window.Pi) throw new Error("Pi SDK no inicializado");
+
+    const { accessToken } = await window.Pi.authenticate(["username", "payments"]);
+
+    const resp = await fetch(postUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-CSRFToken": getCsrf() },
+      body: JSON.stringify({ accessToken }),
+    });
+
+    if (!resp.ok) {
+      const t = await resp.text().catch(() => "");
+      throw new Error(`pi_login falló: ${resp.status} ${t}`);
+    }
+
+    // Redirección (prioriza ?next=)
+    const urlNext = new URLSearchParams(window.location.search).get("next");
+    window.location = urlNext || onSuccessRedirect || "/";
+  } catch (e) {
+    console.error(e);
+    alert(
+      "No se pudo iniciar sesión con Pi.\n" +
+      "Verifica:\n• Estás en Pi Browser\n• Pi.init() ejecutado\n• Sandbox autorizado hoy"
+    );
+  }
+}

--- a/users/context_processors.py
+++ b/users/context_processors.py
@@ -4,3 +4,6 @@ def recaptcha_keys(request):
     return {
         "RECAPTCHA_SITE_KEY": getattr(settings, "RECAPTCHA_SITE_KEY", ""),
     }
+
+def pi_flags(request):
+    return {"PI_ONLY_LOGIN": getattr(settings, "PI_ONLY_LOGIN", False)}

--- a/users/templates/accounts/login.html
+++ b/users/templates/accounts/login.html
@@ -1,6 +1,5 @@
-{# templates/accounts/login.html #}
 {% extends "base.html" %}
-{% load static %}  
+{% load static %}
 {% block title %}Iniciar sesión{% endblock %}
 
 {% block content %}
@@ -8,75 +7,123 @@
   <div class="col-12 col-md-6 col-lg-4">
     <h1 class="h3 mb-3">Iniciar sesión</h1>
 
-    <form id="login-form" method="post" novalidate>
-      {% csrf_token %}
-      {{ form.non_field_errors }}
-
-      <div class="mb-3">
-        <label class="form-label">Usuario</label>
-        {{ form.username }}
-      </div>
-      <div class="mb-3">
-        <label class="form-label">Contraseña</label>
-        {{ form.password }}
+    {% if PI_ONLY_LOGIN %}
+      <div class="alert alert-info">
+        Durante la revisión del Core Team, el acceso es <strong>solo con Pi</strong>.
       </div>
 
-      <!-- reCAPTCHA v3 -->
-      {{ form.recaptcha_token }}
+      <button class="btn btn-primary w-100" type="button" onclick="loginWithPi()">
+        Iniciar sesión con Pi
+      </button>
 
-
-      <button class="btn btn-primary w-100" type="submit">Entrar</button>
-    </form>
-
-<!-- Aviso reCAPTCHA con tarjeta ligera e icono -->
-<div class="mt-3">
-  <div class="d-flex align-items-start gap-2 small text-muted border rounded-3 p-3 bg-light">
-    <!-- Shield Check (inline SVG) -->
-    <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false" class="mt-1">
-      <path d="M12 2l7 3v6c0 5-3.8 9.7-7 11-3.2-1.3-7-6-7-11V5l7-3z" fill="currentColor" opacity=".15"></path>
-      <path d="M12 2l7 3v6c0 5-3.8 9.7-7 11-3.2-1.3-7-6-7-11V5l7-3zm0 2.2L7 5.3v5.6c0 3.9 2.8 8 5 9.3 2.2-1.3 5-5.4 5-9.3V5.3l-5-1.1zM10.9 14.6l-2.1-2.1 1.4-1.4 1.4 1.4 3.3-3.3 1.4 1.4-4.7 4.7z" fill="currentColor"></path>
-    </svg>
-    <div>
-      <div class="fw-semibold">Protección activa con Google reCAPTCHA v3</div>
-      <div>
-        Esta página está protegida por reCAPTCHA y se aplican la
-        <a class="link-secondary" href="https://policies.google.com/privacy" rel="noopener noreferrer" target="_blank">Política de Privacidad</a>
-        y los
-        <a class="link-secondary" href="https://policies.google.com/terms" rel="noopener noreferrer" target="_blank">Términos de Servicio</a>
-        de Google.
+      <div class="mt-3 small text-muted">
+        ¿Problemas? Abre esta app desde <strong>Pi Browser</strong> y vuelve a intentarlo.
       </div>
-    </div>
-  </div>
-</div>
 
-<!-- Acciones de cuenta en una “barra” elegante -->
-<div class="mt-3">
-  <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center gap-2 border rounded-3 p-3">
-    <div class="d-flex align-items-center gap-2">
-      <!-- User Plus (inline SVG) -->
-      <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M15 14c2.8 0 5 2.2 5 5v1H4v-1c0-2.8 2.2-5 5-5h6zM9 5a4 4 0 118 0 4 4 0 01-8 0z" fill="currentColor" opacity=".15"></path>
-        <path d="M12 13c3.3 0 6 2.7 6 6v1H6v-1c0-3.3 2.7-6 6-6zm0-10a4 4 0 110 8 4 4 0 010-8zM20 7h-2V5h-2V3h2V1h2v2h2v2h-2v2z" fill="currentColor"></path>
-      </svg>
-      <span class="small">¿Sin cuenta?</span>
-      <a class="btn btn-sm btn-outline-primary"
-         href="{% url 'users:register' %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}">
-        Regístrate
-      </a>
-    </div>
-    <div>
-      <a class="small link-primary" href="{% url 'users:password_reset' %}">
-        ¿Olvidaste tu contraseña?
-      </a>
-    </div>
-  </div>
-</div>
+    {% else %}
+      <form id="login-form" method="post" novalidate>
+        {% csrf_token %}
+        {{ form.non_field_errors }}
 
+        <div class="mb-3">
+          <label class="form-label">Usuario</label>
+          {{ form.username }}
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Contraseña</label>
+          {{ form.password }}
+        </div>
+
+        <!-- reCAPTCHA v3 -->
+        {{ form.recaptcha_token }}
+
+        <button class="btn btn-primary w-100" type="submit">Entrar</button>
+      </form>
+
+      <!-- Aviso reCAPTCHA -->
+      <div class="mt-3">
+        <div class="d-flex align-items-start gap-2 small text-muted border rounded-3 p-3 bg-light">
+          <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" class="mt-1">
+            <path d="M12 2l7 3v6c0 5-3.8 9.7-7 11-3.2-1.3-7-6-7-11V5l7-3z" fill="currentColor" opacity=".15"></path>
+            <path d="M12 2l7 3v6c0 5-3.8 9.7-7 11-3.2-1.3-7-6-7-11V5l7-3zm0 2.2L7 5.3v5.6c0 3.9 2.8 8 5 9.3 2.2-1.3 5-5.4 5-9.3V5.3l-5-1.1zM10.9 14.6l-2.1-2.1 1.4-1.4 1.4 1.4 3.3-3.3 1.4 1.4-4.7 4.7z" fill="currentColor"></path>
+          </svg>
+          <div>
+            <div class="fw-semibold">Protección activa con Google reCAPTCHA v3</div>
+            <div>
+              Esta página está protegida por reCAPTCHA y se aplican la
+              <a class="link-secondary" href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Política de Privacidad</a>
+              y los
+              <a class="link-secondary" href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">Términos de Servicio</a>
+              de Google.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Acciones de cuenta -->
+      <div class="mt-3">
+        <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center gap-2 border rounded-3 p-3">
+          <div class="d-flex align-items-center gap-2">
+            <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M15 14c2.8 0 5 2.2 5 5v1H4v-1c0-2.8 2.2-5 5-5h6zM9 5a4 4 0 118 0 4 4 0 01-8 0z" fill="currentColor" opacity=".15"></path>
+              <path d="M12 13c3.3 0 6 2.7 6 6v1H6v-1c0-3.3 2.7-6 6-6zm0-10a4 4 0 110 8 4 4 0 010-8zM20 7h-2V5h-2V3h2V1h2v2h2v2h-2v2z" fill="currentColor"></path>
+            </svg>
+            <span class="small">¿Sin cuenta?</span>
+            <a class="btn btn-sm btn-outline-primary"
+               href="{% url 'users:register' %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}">
+              Regístrate
+            </a>
+          </div>
+          <div>
+            <a class="small link-primary" href="{% url 'users:password_reset' %}">
+              ¿Olvidaste tu contraseña?
+            </a>
+          </div>
+        </div>
+      </div>
+    {% endif %}
   </div>
 </div>
 {% endblock %}
 
 {% block extra_scripts %}
-  <script src="https://www.google.com/recaptcha/api.js?render={{ RECAPTCHA_SITE_KEY }}"></script>
-  <script src="{% static 'js/recaptcha-login.js' %}"></script>
+  {% if not PI_ONLY_LOGIN %}
+    <script src="https://www.google.com/recaptcha/api.js?render={{ RECAPTCHA_SITE_KEY }}"></script>
+    <script src="{% static 'js/recaptcha-login.js' %}"></script>
+  {% endif %}
+
+  <script>
+    // Inicializa el SDK (sandbox=true mientras pruebas en el Sandbox)
+    if (window.Pi) {
+      Pi.init({ version: "2.0", sandbox: true });
+    } else {
+      console.error("Pi SDK no disponible");
+    }
+
+    function getCsrf(name="csrftoken"){
+      return document.cookie.split('; ').find(r=>r.startsWith(name+'='))?.split('=')[1];
+    }
+
+    async function loginWithPi(){
+      try{
+        if (!window.Pi) throw new Error("Pi SDK no cargado");
+        const { accessToken } = await Pi.authenticate(['username','payments']);
+        const resp = await fetch("{% url 'users:pi_login' %}", {
+          method: "POST",
+          headers: {"Content-Type":"application/json", "X-CSRFToken": getCsrf()},
+          body: JSON.stringify({ accessToken })
+        });
+        if(!resp.ok){
+          const t = await resp.text().catch(()=> "");
+          throw new Error("pi_login falló: " + (t || resp.status));
+        }
+        const next = new URLSearchParams(window.location.search).get("next");
+        window.location = next || "{% url 'users:profile' %}";
+      }catch(e){
+        console.error(e);
+        alert("No se pudo iniciar sesión con Pi. Revisa:\n• Estás en Pi Browser\n• Pi.init() ejecutado\n• Sandbox autorizado hoy");
+      }
+    }
+  </script>
+
 {% endblock %}

--- a/users/templates/accounts/pi_only.html
+++ b/users/templates/accounts/pi_only.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container py-5">
+  <h1>Acceso solo con Pi</h1>
+  <p class="text-muted">Durante la revisión del Core Team, el inicio de sesión y registro se hacen únicamente con Pi.</p>
+  <button class="btn btn-primary" onclick="loginWithPi()">Iniciar sesión con Pi</button>
+</div>
+
+<script src="https://downloads.minepi.com/sdk/v1/prod.js"></script>
+<script>
+  function getCsrf(n="csrftoken"){
+    return document.cookie.split('; ').find(v=>v.startsWith(n+'='))?.split('=')[1]
+  }
+  async function loginWithPi(){
+    try{
+      const { accessToken } = await Pi.authenticate(['username','payments']);
+      const r = await fetch("{% url 'users:pi_login' %}", {
+        method: "POST",
+        headers: {"Content-Type":"application/json","X-CSRFToken":getCsrf()},
+        body: JSON.stringify({ accessToken })
+      });
+      if(!r.ok) throw new Error("Login Pi falló");
+      window.location = "{% url 'users:profile' %}";
+    }catch(e){
+      alert("No se pudo iniciar sesión con Pi"); console.error(e);
+    }
+  }
+</script>
+{% endblock %}

--- a/users/urls.py
+++ b/users/urls.py
@@ -7,6 +7,9 @@ from .forms import StyledAuthenticationForm, StyledPasswordChangeForm
 app_name = "users"
 
 urlpatterns = [
+    # --- Pi auth ---
+    path("pi/login/", views.pi_login, name="pi_login"),
+    
     # Autenticación
     path(
         "login/",
@@ -81,4 +84,5 @@ urlpatterns = [
         ),
         name="password_change_done",
     ),
+    
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,17 +1,19 @@
-# users/views.py
 from __future__ import annotations
-
 from pathlib import Path
+import json, requests
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import login, logout
+from django.contrib.auth import login, logout, get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView as DjangoLoginView
-from django.http import FileResponse, Http404
+from django.http import FileResponse, Http404, JsonResponse, HttpResponseBadRequest
 from django.shortcuts import redirect, render
 from django.urls import NoReverseMatch, reverse, reverse_lazy
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.decorators import method_decorator
+from django.views.decorators.http import require_POST
+from django.views.decorators.csrf import ensure_csrf_cookie, csrf_protect
 
 from .forms import (
     CustomUserCreationForm,
@@ -20,9 +22,11 @@ from .forms import (
 )
 from .models import AVATAR_CHOICES
 
+PI_API_BASE = "https://api.minepi.com/v2"
+User = get_user_model()
+
 
 # ---------- Helpers ----------
-
 def _safe_redirect(request, fallback: str | None = None):
     """
     Redirige a ?next= si es del mismo host; si no, usa 'fallback'.
@@ -36,16 +40,70 @@ def _safe_redirect(request, fallback: str | None = None):
     return redirect(getattr(settings, "LOGIN_REDIRECT_URL", "/"))
 
 
-# ---------- Auth Views ----------
+def _pick_backend() -> str:
+    """
+    Elige el backend de autenticación para login() cuando no venimos de authenticate().
+    Prioriza ModelBackend si existe; si no, el primero configurado.
+    """
+    for b in settings.AUTHENTICATION_BACKENDS:
+        if b.endswith("ModelBackend"):
+            return b
+    return settings.AUTHENTICATION_BACKENDS[0]
 
+
+# ---------- Pi Auth ----------
+@require_POST
+@csrf_protect
+def pi_login(request):
+    data = json.loads(request.body or "{}")
+    token = data.get("accessToken")
+    if not token:
+        return HttpResponseBadRequest("Falta accessToken")
+
+    # Verifica token con /me
+    r = requests.get(f"{PI_API_BASE}/me", headers={"Authorization": f"Bearer {token}"})
+    if not r.ok:
+        return JsonResponse({"ok": False, "reason": "token inválido"}, status=401)
+
+    me = r.json()
+    pi_uid = (me.get("uid") or "").strip()
+    pi_username = (me.get("username") or "pi_user").strip() or "pi_user"
+
+    # Usuario local asociado al uid de Pi
+    username = f"pi_{pi_uid}"
+    user, created = User.objects.get_or_create(
+        username=username,
+        defaults={"email": f"{pi_username}@pi.local"}
+    )
+    # Evita login por password en cuentas creadas desde Pi (opcional pero sensato)
+    if created:
+        user.set_unusable_password()
+        user.save(update_fields=["password"])
+
+    # Importante: con múltiples AUTHENTICATION_BACKENDS, hay que indicar el backend
+    login(request, user, backend=_pick_backend())
+    return JsonResponse({"ok": True})
+
+
+@ensure_csrf_cookie
+def pi_only_notice(request):
+    return render(request, "accounts/pi_only.html", status=403)
+
+
+# ---------- Auth Views ----------
+@method_decorator(ensure_csrf_cookie, name="dispatch")
 class LoginView(DjangoLoginView):
     """
-    Login con mensajes de éxito/error y formulario estilizado.
-    (Si en urls usas auth_views.LoginView, esta clase no se usa.)
+    Login clásico (form) o sólo-Pi según flag en settings.
     """
     template_name = "accounts/login.html"
     redirect_authenticated_user = True
     authentication_form = StyledAuthenticationForm
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["PI_ONLY_LOGIN"] = getattr(settings, "PI_ONLY_LOGIN", False)
+        return ctx
 
     def form_valid(self, form):
         messages.success(self.request, "Has iniciado sesión. ¡Bienvenido de nuevo!")
@@ -56,6 +114,7 @@ class LoginView(DjangoLoginView):
         return super().form_invalid(form)
 
 
+# ---------- Registro / Perfil / Otros ----------
 def register(request):
     """
     Registro + login automático + mensaje + respeto de ?next=.
@@ -67,9 +126,8 @@ def register(request):
         form = CustomUserCreationForm(request.POST)
         if form.is_valid():
             user = form.save()
-            login(request, user)
+            login(request, user, backend=_pick_backend())  # explícito por consistencia
             messages.success(request, "Registro completado. ¡Bienvenido!")
-            # Fallback: perfil si no hay ?next=
             return _safe_redirect(request, fallback=reverse_lazy("users:profile"))
         messages.error(request, "Revisa los errores del formulario.")
     else:
@@ -87,7 +145,6 @@ def profile(request):
       - Atajos a cambiar contraseña / CV / logout
       - Enlace a pedidos si existe la app orders
     """
-    # Como no hay subida de archivo, NO necesitamos request.FILES
     if request.method == "POST":
         form = ProfileUpdateForm(request.POST, instance=request.user)
         if form.is_valid():
@@ -103,7 +160,7 @@ def profile(request):
     orders_count = None
     last_order = None
     try:
-        from orders.models import Order  # si no existe, saltará ImportError
+        from orders.models import Order  # noqa: WPS433
         try:
             orders_url = reverse("orders:list")
         except NoReverseMatch:
@@ -122,7 +179,7 @@ def profile(request):
         "orders_url": orders_url,
         "orders_count": orders_count,
         "last_order": last_order,
-        "avatar_choices": AVATAR_CHOICES,  # para pintar la galería en la plantilla
+        "avatar_choices": AVATAR_CHOICES,
     }
     return render(request, "accounts/profile.html", ctx)
 
@@ -145,7 +202,7 @@ def cv_gate(request):
         "accounts/cv_gate.html",
         {
             "download_url": reverse_lazy("users:cv_download"),
-            "redirect_to": "/",  # si tu home tiene name, usa reverse_lazy("NOMBRE_HOME")
+            "redirect_to": "/",
         },
     )
 


### PR DESCRIPTION
add pi_login endpoint with server-side validation against Pi /me and CSRF protection

explicitly pass auth backend to login() to support multiple backends

set unusable password for Pi-provisioned users

inject PI_ONLY_LOGIN flag in LoginView context to toggle UI

update login template to show Pi login button and hide classic form when PI_ONLY_LOGIN is enabled

load pi-sdk.js and initialize in login page for sandbox testing

ensure CSRF cookie on LoginView and pi_only_notice

clean base.html to a single extra_scripts block

remove duplicate pi_login definition inside register

docs/settings: add CSRF_TRUSTED_ORIGINS