### PR TITLE
Fix skills icons sizing by scoping styles and allowing larger variants

### DIFF
--- a/core/templates/home.html
+++ b/core/templates/home.html
@@ -69,17 +69,17 @@
   <!-- Tecnologías (lazy) -->
   <div class="mt-4 text-center">
     <h5>Tecnologías</h5>
-    <div class="d-flex justify-content-center flex-wrap mt-3">
-      <img src="{% static 'icons/git.png' %}"         alt="Git"        width="30px" class="m-2" loading="lazy" decoding="async">
-      <img src="{% static 'icons/html5.png' %}"       alt="HTML5"      width="30px" class="m-2" loading="lazy" decoding="async">
-      <img src="{% static 'icons/css3.png' %}"        alt="CSS3"       width="30px" class="m-2" loading="lazy" decoding="async">
-      <img src="{% static 'icons/javascript.png' %}"  alt="JavaScript" width="30px" class="m-2" loading="lazy" decoding="async">
-      <img src="{% static 'icons/python.png' %}"      alt="Python"     width="30px" class="m-2" loading="lazy" decoding="async">
-      <img src="{% static 'icons/django.png' %}"      alt="Django"     width="30px" class="m-2" loading="lazy" decoding="async">
-      <img src="{% static 'icons/bootstrap.png' %}"   alt="Bootstrap"  width="30px" class="m-2" loading="lazy" decoding="async">
-      <img src="{% static 'icons/react.png' %}"       alt="React"      width="30px" class="m-2" loading="lazy" decoding="async">
-      <img src="{% static 'icons/mysql.png' %}"       alt="MySQL"      width="30px" class="m-2" loading="lazy" decoding="async">
-      <img src="{% static 'icons/vite.png' %}"        alt="Vite"       width="30px" class="m-2" loading="lazy" decoding="async">
+    <div class="d-flex justify-content-center flex-wrap mt-3 skills-icons">
+      <img src="{% static 'icons/git.png' %}"         alt="Git"        class="m-2" loading="lazy" decoding="async">
+      <img src="{% static 'icons/html5.png' %}"       alt="HTML5"      class="m-2" loading="lazy" decoding="async">
+      <img src="{% static 'icons/css3.png' %}"        alt="CSS3"       class="m-2" loading="lazy" decoding="async">
+      <img src="{% static 'icons/javascript.png' %}"  alt="JavaScript" class="m-2" loading="lazy" decoding="async">
+      <img src="{% static 'icons/python.png' %}"      alt="Python"     class="m-2" loading="lazy" decoding="async">
+      <img src="{% static 'icons/django.png' %}"      alt="Django"     class="m-2" loading="lazy" decoding="async">
+      <img src="{% static 'icons/bootstrap.png' %}"   alt="Bootstrap"  class="m-2" loading="lazy" decoding="async">
+      <img src="{% static 'icons/react.png' %}"       alt="React"      class="m-2" loading="lazy" decoding="async">
+      <img src="{% static 'icons/mysql.png' %}"       alt="MySQL"      class="m-2" loading="lazy" decoding="async">
+      <img src="{% static 'icons/vite.png' %}"        alt="Vite"       class="m-2" loading="lazy" decoding="async">
     </div>
   </div>
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -119,8 +119,14 @@ h1:hover { color: var(--secondary-color); transform: scale(1.05); transition: tr
 
 .profile-card:hover { transform: translateY(-10px); box-shadow: 0 12px 25px rgba(0, 0, 0, 0.5);}
 
-/* Iconos habilidades */
-.d-flex img { max-width: 25px; margin: 0 10px; transition: transform 0.3s ease, filter 0.3s ease; animation: scaleUp var(--animation-duration) var(--animation-ease); transition: transform 0.3s ease, filter 0.3s ease;}
+/* Después: limita el estilo solo a tu sección de skills */
+.skills-icons img {width: 40px; height: auto; margin: 0 10px; transition: transform .3s ease, filter .3s ease; animation: scaleUp var(--animation-duration, .6s) var(--animation-ease, ease);}
+
+/* Tamaño mayor para algunos */
+.skills-icons img.tech-icon-lg { width: 60px; }
+
+/* Hover opcional */
+.skills-icons img:hover { transform: translateY(-2px) scale(1.05); filter: saturate(1.1);}
 
 .d-flex img:hover { transform: scale(1.5);}
 


### PR DESCRIPTION
* Remove global selector that forced all .d-flex img to max width 25px
* Add scoped container class skills-icons for the tech row
* Set default icon width 30px with clean single transition and CSS var fallbacks
* Add optional tech-icon-lg utility to render selected icons at 60px
* Update template markup to use skills-icons and tech-icon-lg on the Python icon
* Keep hover animation and visual polish consistent across icons